### PR TITLE
S3に保存されたデータを別のS3にコピーするラムダの追加

### DIFF
--- a/cdk_ts/lib/cdk_ts-stack.ts
+++ b/cdk_ts/lib/cdk_ts-stack.ts
@@ -93,7 +93,7 @@ export class CdkTsStack extends Stack {
       this,
       "copyfromS3ToS3",
       {
-        entry: path.join(__dirname, "/../../lambda/ts/putToS3.ts"),
+        entry: path.join(__dirname, "/../../lambda/ts/copyToS3.ts"),
         runtime: lambda.Runtime.NODEJS_16_X,
         handler: "handler",
         depsLockFilePath: path.join(
@@ -101,7 +101,8 @@ export class CdkTsStack extends Stack {
           "/../../lambda/ts/package-lock.json"
         ),
         environment: {
-          BUCKET_NAME: cloneBucket.bucketName,
+          SRC_BUCKET_NAME: bucket.bucketName,
+          DIST_BUCKET_NAME: cloneBucket.bucketName,
         },
         role: roleForCopy,
       }

--- a/cdk_ts/package-lock.json
+++ b/cdk_ts/package-lock.json
@@ -1519,12 +1519,14 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1736,7 +1738,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/constructs": {
       "version": "10.1.174",
@@ -3373,6 +3376,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3662,6 +3666,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3777,6 +3782,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }

--- a/cdk_ts/package.json
+++ b/cdk_ts/package.json
@@ -14,9 +14,9 @@
     "@types/jest": "^27.5.2",
     "@types/node": "10.17.27",
     "@types/prettier": "2.6.0",
+    "aws-cdk": "2.50.0",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
-    "aws-cdk": "2.50.0",
     "ts-node": "^10.9.1",
     "typescript": "~3.9.7"
   },

--- a/lambda/ts/copyToS3.ts
+++ b/lambda/ts/copyToS3.ts
@@ -11,13 +11,16 @@ AWS.config.apiVersions = {
 };
 
 export const handler = async (event: any) => {
+  const filename =
+    event.Records[0].s3.object.key + event.Records[0].eventTime + ".json";
+
   const client = new S3Client({});
-  const params: PutObjectCommandInput = {
-    Bucket: process.env.BUCKET_NAME,
-    Key: "test.txt",
+  const paramsFroWrite: PutObjectCommandInput = {
+    Bucket: process.env.DIST_BUCKET_NAME,
+    Key: filename,
     Body: JSON.stringify(event),
   };
-  const putCommand = new PutObjectCommand(params);
+  const putCommand = new PutObjectCommand(paramsFroWrite);
   await client.send(putCommand);
   return {
     statusCode: 200,

--- a/lambda/ts/copyToS3.ts
+++ b/lambda/ts/copyToS3.ts
@@ -2,26 +2,61 @@ import AWS from "aws-sdk";
 import {
   S3Client,
   PutObjectCommand,
+  GetObjectCommand,
   PutObjectCommandInput,
+  GetObjectCommandInput,
 } from "@aws-sdk/client-s3";
+import { Readable } from "readable-stream";
 
 AWS.config.update({ region: "ap-northeast-1" });
 AWS.config.apiVersions = {
   s3: "2006-03-01",
 };
 
+const streamToString = (stream: Readable) => {
+  const chunks: Uint8Array[] = [];
+  return new Promise((resolve, reject) => {
+    stream.on("data", (chunk) => chunks.push(chunk));
+    stream.on("error", reject);
+    stream.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+  });
+};
+
 export const handler = async (event: any) => {
-  const filename =
-    event.Records[0].s3.object.key + event.Records[0].eventTime + ".json";
+  const eventTime = event.Records[0].eventTime;
+  const filename = event.Records[0].s3.object.key;
 
   const client = new S3Client({});
-  const paramsFroWrite: PutObjectCommandInput = {
-    Bucket: process.env.DIST_BUCKET_NAME,
+  const paramsForRead: GetObjectCommandInput = {
+    Bucket: process.env.SRC_BUCKET_NAME,
     Key: filename,
-    Body: JSON.stringify(event),
   };
-  const putCommand = new PutObjectCommand(paramsFroWrite);
-  await client.send(putCommand);
+  const getCommand = new GetObjectCommand(paramsForRead);
+  try {
+    const res = await client.send(getCommand);
+    const body = res.Body as Readable;
+    const bodyString = await streamToString(body);
+
+    const paramsForWrite: PutObjectCommandInput = {
+      Bucket: process.env.DIST_BUCKET_NAME,
+      Key: eventTime + "_" + filename,
+      Body: JSON.stringify({
+        name: filename,
+        contents: bodyString,
+      }),
+    };
+    const putCommand = new PutObjectCommand(paramsForWrite);
+    await client.send(putCommand);
+  } catch (err) {
+    console.log(err);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        message: err,
+      }),
+    };
+  }
+
   return {
     statusCode: 200,
     body: JSON.stringify({

--- a/lambda/ts/package-lock.json
+++ b/lambda/ts/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.218.0",
         "@types/node": "^18.11.9",
+        "@types/readable-stream": "^2.3.15",
         "aws-sdk": "^2.1263.0",
         "typescript": "^4.9.3"
       }
@@ -1312,6 +1313,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
       "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
     },
+    "node_modules/@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -1579,6 +1589,11 @@
       "engines": {
         "node": ">=0.4.x"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/sax": {
       "version": "1.2.1",

--- a/lambda/ts/package.json
+++ b/lambda/ts/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.218.0",
     "@types/node": "^18.11.9",
+    "@types/readable-stream": "^2.3.15",
     "aws-sdk": "^2.1263.0",
     "typescript": "^4.9.3"
   }

--- a/lambda/ts/putToS3.ts
+++ b/lambda/ts/putToS3.ts
@@ -13,7 +13,7 @@ AWS.config.apiVersions = {
 export const handler = async (event: any) => {
   const client = new S3Client({});
   const params: PutObjectCommandInput = {
-    Bucket: "cdk-ts-practice-bucket",
+    Bucket: process.env.BUCKET_NAME,
     Key: "test.txt",
     Body: "Hello World!",
   };

--- a/lambda/ts/putToS3.ts
+++ b/lambda/ts/putToS3.ts
@@ -18,7 +18,16 @@ export const handler = async (event: any) => {
     Body: JSON.stringify(event),
   };
   const putCommand = new PutObjectCommand(params);
-  await client.send(putCommand);
+  try {
+    await client.send(putCommand);
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        message: err,
+      }),
+    };
+  }
   return {
     statusCode: 200,
     body: JSON.stringify({


### PR DESCRIPTION
- practiceBucketからpracticeBucketCloneへとコピーするラムダ
  - PutObjectEventで発火
  - S3に保存されたデータの取得
    - types/readable-streamを追加
 
参考
https://makky12.hatenablog.com/entry/2022/07/25/120500